### PR TITLE
Added normalize_dir_path function, updating gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ venv/
 ubuntu_venv/
 *.pyc
 .idea
+*.json

--- a/input/address_pairs.csv
+++ b/input/address_pairs.csv
@@ -1,2 +1,5 @@
 ﻿Index File Name,Address 1,Address 1 GIMP X Coordinate,Address 1 GIMP Y Coordinate,Address 2,Address 2 GIMP X Coordinate,Address 2 GIMP Y Coordinate
 macomb61Index.pdf,"Bordman Road and Fisher Road, Bruce Township, MI 48065",315.4,2926.1,"Jefferson Avenue and E 9 Mile Road, St Clair Shores, MI 48080 ",1175.8,488.2
+wayne67Index.pdf,"Hoover Street and 7 Mile, Detroit, MI 48205",1841.8,1956.2,"Sumpter Road and Newburg Road, Exeter Township, MI 48117",417.6,491.8
+wayne52Index.pdf,"Hoover Street and 7 Mile, Detroit, MI 48205",2209.7,2146.3,"Sumpter Road and Newburg Road, Exeter Township, MI 48117",560.9,450.7
+wayne81Index.pdf,"Hoover Street and 7 Mile, Detroit, MI 48205",2186.6,2180.2,"Sumpter Road and Newburg Road, Exeter Township, MI 48117",352.8,294.5

--- a/misc_functions.py
+++ b/misc_functions.py
@@ -84,3 +84,9 @@ def load_csv_data(csv_file_name):
         print('-- CSV file was not found at that path --')
         csv_data = {}
     return csv_data
+
+def normalize_dir_path(dir_path):
+    if dir_path[-1] != '/':
+        return dir_path + '/'
+    else:
+        return dir_path

--- a/process_batch.py
+++ b/process_batch.py
@@ -239,8 +239,7 @@ if __name__=="__main__":
     try:
         output_directory_path = sys.argv[3]
         # to handle output directories with or without trailing slash
-        if output_directory_path[-1] != "/":
-            output_directory_path = output_directory_path + "/"
+        output_directory_path = misc_functions.normalize_dir_path(output_directory_path)
     except:
         # proof of concept directory
         output_directory_path = 'output/'
@@ -249,7 +248,7 @@ if __name__=="__main__":
     misc_functions.set_up_output_subdirectory(output_directory_path, "pypdf2")
 
     # Creating or loading image records and georeferenced link records
-    county_year_combo = '_'.join(batch_directory_path.split('/')[-2:])
+    county_year_combo = '_'.join(misc_functions.normalize_dir_path(batch_directory_path).split('/')[-3:-1])
     batch_metadata, georeferenced_link_data = process_or_load(data_gathering_mode, batch_directory_path, output_directory_path, county_year_combo)
 
     index_file_name = batch_metadata['Index Records'][0]['Index File Name']


### PR DESCRIPTION
I added a `normalize_dir_path()` function to `misc_functions.py` that makes sure output directory path ends in `/`.  I also added `*.json` to `.gitignore` to prevent tracking of arcgis cache file.